### PR TITLE
add: verification of authenticated user to perform actions on collection calls

### DIFF
--- a/backend/app/serializers.py
+++ b/backend/app/serializers.py
@@ -72,7 +72,7 @@ class CollectionCallSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 {"amount_to_collected": "O valor a ser coletado deve ser maior que zero."}
             )
-        elif isinstance(value, (int, float)):
+        elif not isinstance(value, (int, float)):
             raise serializers.ValidationError(
                 {"amount_to_collected": "O valor a ser coletado deve ser um número."}
             )


### PR DESCRIPTION
- Now, when creating collection calls the user id is recovered from the logged user id, instead of passing via payload;
- Now, users can only edit their own collection calls;
- Now, users can retrieve info about their own collection calls;